### PR TITLE
PR Review for #328

### DIFF
--- a/Sources/MockoloFramework/Models/ConditionalImportBlock.swift
+++ b/Sources/MockoloFramework/Models/ConditionalImportBlock.swift
@@ -26,7 +26,6 @@ struct ConditionalImportBlock {
     struct Clause {
         var type: ClauseType
         var contents: [ImportContent]
-        var order: Int
     }
 
     let clauses: [Clause]

--- a/Sources/MockoloFramework/Models/ConditionalImportBlock.swift
+++ b/Sources/MockoloFramework/Models/ConditionalImportBlock.swift
@@ -33,15 +33,9 @@ indirect enum ImportContent {
 struct ConditionalImportBlock {
     /// Represents a single clause in a conditional import block
     struct Clause {
-        let type: ClauseType
-        let condition: String?  // nil for #else
+        var type: ClauseType
         var contents: [ImportContent]
-
-        init(type: ClauseType, condition: String?, contents: [ImportContent]) {
-            self.type = type
-            self.condition = condition
-            self.contents = contents
-        }
+        var order: Int
     }
 
     let clauses: [Clause]

--- a/Sources/MockoloFramework/Models/ConditionalImportBlock.swift
+++ b/Sources/MockoloFramework/Models/ConditionalImportBlock.swift
@@ -18,15 +18,6 @@
 indirect enum ImportContent {
     case simple(Import)
     case conditional(ConditionalImportBlock)
-
-    var isConditional: Bool {
-        switch self {
-        case .simple:
-            false
-        case .conditional:
-            true
-        }
-    }
 }
 
 /// Represents a conditional import block (#if/#elseif/#else/#endif)

--- a/Sources/MockoloFramework/Models/IfMacroModel.swift
+++ b/Sources/MockoloFramework/Models/IfMacroModel.swift
@@ -35,7 +35,6 @@ final class IfMacroModel: Model {
     struct Clause {
         var type: ClauseType
         var entities: [(String, Model)]
-        var order: Int
     }
 
     let clauses: [Clause]
@@ -63,7 +62,7 @@ final class IfMacroModel: Model {
     convenience init(name: String,
                      offset: Int64,
                      entities: [(String, Model)]) {
-        let clause = Clause(type: .if(name), entities: entities, order: 0)
+        let clause = Clause(type: .if(name), entities: entities)
         self.init(clauses: [clause], offset: offset)
     }
 

--- a/Sources/MockoloFramework/Models/IfMacroModel.swift
+++ b/Sources/MockoloFramework/Models/IfMacroModel.swift
@@ -15,20 +15,17 @@
 //
 
 /// Represents the type of a clause in an #if/#elseif/#else block
-public enum ClauseType: Comparable {
-    case `if`
-    case elseif(order: Int)
+enum ClauseType {
+    case `if`(_ condition: String)
+    case elseif(_ condition: String)
     case `else`
 
-    // Comparable implementation: if < elseif(0) < elseif(1) < ... < else
-    public static func < (lhs: ClauseType, rhs: ClauseType) -> Bool {
-        switch (lhs, rhs) {
-        case (.if, .elseif), (.if, .else), (.elseif, .else):
-            true
-        case (.elseif(let l), .elseif(let r)):
-            l < r
-        default:
-            false
+    var condition: String? {
+        switch self {
+        case .if(let condition), .elseif(let condition):
+            return condition
+        case .else:
+            return nil
         }
     }
 }
@@ -36,9 +33,9 @@ public enum ClauseType: Comparable {
 final class IfMacroModel: Model {
     /// Represents a single clause in a conditional compilation block
     struct Clause {
-        let type: ClauseType
-        let condition: String?  // nil for #else
-        let entities: [(String, Model)]
+        var type: ClauseType
+        var entities: [(String, Model)]
+        var order: Int
     }
 
     let clauses: [Clause]
@@ -49,7 +46,7 @@ final class IfMacroModel: Model {
     }
     
     var name: String {
-        clauses.first?.condition ?? ""
+        clauses.first?.type.condition ?? ""
     }
 
     var fullName: String {
@@ -66,7 +63,7 @@ final class IfMacroModel: Model {
     convenience init(name: String,
                      offset: Int64,
                      entities: [(String, Model)]) {
-        let clause = Clause(type: .if, condition: name, entities: entities)
+        let clause = Clause(type: .if(name), entities: entities, order: 0)
         self.init(clauses: [clause], offset: offset)
     }
 

--- a/Sources/MockoloFramework/Models/Import.swift
+++ b/Sources/MockoloFramework/Models/Import.swift
@@ -15,10 +15,10 @@
 //
 
 /// A structure defining an "import" statement parsed by `Generator`, including various modifiers.
-public struct Import: CustomStringConvertible {
+struct Import: CustomStringConvertible {
     
     /// The access level of the import
-    public enum ACL: String {
+    enum ACL: String {
         case `private`
         case `fileprivate`
         case `internal`
@@ -37,18 +37,18 @@ public struct Import: CustomStringConvertible {
     }
     
     /// A modifier that precedes the "import" keyword. ACL and "@testable" are mutually exclusive.
-    public enum Modifier: RawRepresentable {
+    enum Modifier: RawRepresentable {
         case acl(ACL)
         case testable
         
-        public var rawValue: String {
+        var rawValue: String {
             switch self {
             case .acl(let acl): acl.rawValue
             case .testable: "@testable"
             }
         }
         
-        public init?(rawValue: String) {
+        init?(rawValue: String) {
             if rawValue == "@testable" {
                 self = .testable
             } else if let acl = ACL(rawValue: rawValue) {
@@ -60,19 +60,19 @@ public struct Import: CustomStringConvertible {
     }
     
     /// Name of the module
-    public var moduleName: String
+    var moduleName: String
 
     
     /// A modifier preceding the "import" keyword (e.g. public, internal, @testable)
-    public var modifier: Modifier?
+    var modifier: Modifier?
     
     /// An opaque string preceding the entire import statement (typically `#if FOO\n` for nested macro support)
-    public var prefix: String?
+    var prefix: String?
     
     /// An opaque string following the entire import statement (typically `\n#endif` for nested macro support)
-    public var suffix: String?
+    var suffix: String?
     
-    public var description: String {
+    var description: String {
         let line: String
         if let modifier {
             line = "\(modifier.rawValue) import \(moduleName)"
@@ -82,7 +82,7 @@ public struct Import: CustomStringConvertible {
         return [prefix, line, suffix].compactMap { $0 }.joined()
     }
     
-    public init(
+    init(
         moduleName: String,
         modifier: Modifier? = nil,
         prefix: String? = nil,

--- a/Sources/MockoloFramework/Operations/ImportsHandler.swift
+++ b/Sources/MockoloFramework/Operations/ImportsHandler.swift
@@ -28,27 +28,15 @@ func handleImports(pathToImportsMap: ImportMap,
     // 1. Collect imports from all relevant files
     for (path, parsedImports) in pathToImportsMap {
         guard relevantPaths.contains(path) else { continue }
-        
-        let (topLevels, conditionals) = parsedImports.partitioned(by: { $0.isConditional })
-        
-        // Collect top-level imports
-        topLevelImports.append(
-            contentsOf: topLevels.compactMap {
-                if case ImportContent.simple(let `import`) = $0 {
-                    return `import`
-                }
-                return nil
+
+        for `import` in parsedImports {
+            switch `import` {
+            case .simple(let simple):
+                topLevelImports.append(simple)
+            case .conditional(let conditional):
+                conditionalBlocks.append(conditional)
             }
-        )
-        // Collect conditional blocks
-        conditionalBlocks.append(
-            contentsOf: conditionals.compactMap {
-                if case ImportContent.conditional(let `import`) = $0 {
-                    return `import`
-                }
-                return nil
-            }
-        )
+        }
     }
 
     // 2. Apply excludeImports filter to top-level imports

--- a/Sources/MockoloFramework/Operations/ImportsHandler.swift
+++ b/Sources/MockoloFramework/Operations/ImportsHandler.swift
@@ -77,10 +77,9 @@ private func renderImportContents(
     var clauseLines: [String] = []
     var simpleImports: [Import] = []
     func resolveAccumulatedSimpleImports() {
-        var work: [Import] = []
-        swap(&simpleImports, &work)
-        if !work.isEmpty {
-            clauseLines.append(work.resolved().lines())
+        if !simpleImports.isEmpty {
+            clauseLines.append(simpleImports.resolved().lines())
+            simpleImports.removeAll(keepingCapacity: true)
         }
     }
 

--- a/Sources/MockoloFramework/Operations/ImportsHandler.swift
+++ b/Sources/MockoloFramework/Operations/ImportsHandler.swift
@@ -21,7 +21,6 @@ func handleImports(pathToImportsMap: ImportMap,
                    excludeImports: [String]?,
                    testableImports: [String]?,
                    relevantPaths: [String]) -> String {
-
     var topLevelImports: [Import] = []
     var conditionalBlocks: [ConditionalImportBlock] = []
 
@@ -38,100 +37,78 @@ func handleImports(pathToImportsMap: ImportMap,
             }
         }
     }
-
-    // 2. Apply excludeImports filter to top-level imports
-    if let excludes = excludeImports {
-        topLevelImports = topLevelImports.filter { !excludes.contains($0.moduleName) }
-    }
+    
+    // 2. Sort conditional blocks by offset (file appearance order)
+    conditionalBlocks.sort(by: { $0.offset < $1.offset })
 
     // 3. Add custom imports
-    if let customImports = customImports {
-        topLevelImports.append(contentsOf: customImports.map { Import(moduleName: $0) })
+    if let customImports {
+        topLevelImports.append(contentsOf: customImports.map {
+            Import(moduleName: $0)
+        })
+    }
+    if let testableImports {
+        topLevelImports.append(contentsOf: testableImports.map {
+            Import(moduleName: $0).asTestable
+        })
     }
 
-    // 4. Resolve duplicates in top-level imports
-    var resolvedTopLevel = topLevelImports.resolved()
-
-    // 5. Apply testableImports modifier
-    if let testableImportNames = testableImports, !testableImportNames.isEmpty {
-        let (passthroughImports, candidateImports) = resolvedTopLevel.partitioned(by: { testableImportNames.contains($0.moduleName) })
-        let mappedImports = candidateImports.map(\.asTestable)
-        let newImports: [Import] = testableImportNames.compactMap { name in
-            guard !mappedImports.contains(where: { $0.moduleName == name }) else { return nil }
-            return Import(moduleName: name, modifier: .testable)
-        }
-        resolvedTopLevel = (passthroughImports + mappedImports + newImports).resolved()
-    }
-
-    // 6. Sort conditional blocks by offset (file appearance order)
-    let sortedBlocks = conditionalBlocks.sorted(by: { $0.offset < $1.offset })
-
-    // 7. Generate output
-    var lines: [String] = []
-
-    if !resolvedTopLevel.isEmpty {
-        lines.append(resolvedTopLevel.lines())
-    }
-
-    for block in sortedBlocks {
-        lines.append(renderConditionalBlock(block, excludeImports: excludeImports))
-    }
-
-    return lines.joined(separator: "\n")
+    let contents: [ImportContent] = topLevelImports.map { .simple($0) } + conditionalBlocks.map { .conditional($0) }
+    return renderImportContents(
+        contents,
+        excludeImports: excludeImports,
+        testableImports: testableImports
+    )
 }
 
-/// Recursively renders a ConditionalImportBlock
-private func renderConditionalBlock(_ block: ConditionalImportBlock, excludeImports: [String]?) -> String {
-    var result = ""
-
-    for (index, clause) in block.clauses.enumerated() {
-        // Render directive line
-        switch clause.type {
-        case .if(let condition):
-            result += "#if \(condition)\n"
-        case .elseif(let condition):
-            result += "#elseif \(condition)\n"
-        case .else:
-            result += "#else\n"
-        }
-
-        // Render contents of this clause
-        var clauseLines: [String] = []
-        var simpleImports: [Import] = []
-
-        for content in clause.contents {
-            switch content {
-            case .simple(let imp):
-                // Filter excluded imports
-                if let excludes = excludeImports, excludes.contains(imp.moduleName) {
-                    continue
-                }
-                simpleImports.append(imp)
-            case .conditional(let nestedBlock):
-                // First output accumulated simple imports
-                if !simpleImports.isEmpty {
-                    clauseLines.append(simpleImports.resolved().lines())
-                    simpleImports = []
-                }
-                // Recursively render nested block
-                clauseLines.append(renderConditionalBlock(nestedBlock, excludeImports: excludeImports))
-            }
-        }
-
-        // Output remaining simple imports
-        if !simpleImports.isEmpty {
-            clauseLines.append(simpleImports.resolved().lines())
-        }
-
-        let clauseContent = clauseLines.joined(separator: "\n")
-        if !clauseContent.isEmpty {
-            result += clauseContent
-            if index < block.clauses.count - 1 {
-                result += "\n"
-            }
+private func renderImportContents(
+    _ contents: [ImportContent],
+    excludeImports: [String]?,
+    testableImports: [String]?
+) -> String {
+    var clauseLines: [String] = []
+    var simpleImports: [Import] = []
+    func resolveAccumulatedSimpleImports() {
+        var work: [Import] = []
+        swap(&simpleImports, &work)
+        if !work.isEmpty {
+            clauseLines.append(work.resolved().lines())
         }
     }
 
-    result += "\n#endif"
-    return result
+    for content in contents {
+        switch content {
+        case .simple(var `import`):
+            if let excludeImports, excludeImports.contains(`import`.moduleName) {
+                continue
+            }
+            if let testableImports, testableImports.contains(`import`.moduleName) {
+                `import` = `import`.asTestable
+            }
+            simpleImports.append(`import`)
+        case .conditional(let block):
+            // First output accumulated simple imports
+            resolveAccumulatedSimpleImports()
+
+            var result = ""
+            for clause in block.clauses {
+                switch clause.type {
+                case .if(let condition):
+                    result += "#if \(condition)\n"
+                case .elseif(let condition):
+                    result += "#elseif \(condition)\n"
+                case .else:
+                    result += "#else\n"
+                }
+                // Recursively render nested block
+                result += renderImportContents(clause.contents, excludeImports: excludeImports, testableImports: testableImports)
+                result += "\n"
+            }
+            result += "#endif"
+            clauseLines.append(result)
+        }
+    }
+    resolveAccumulatedSimpleImports()
+
+    return clauseLines.joined(separator: "\n")
 }

--- a/Sources/MockoloFramework/Operations/ImportsHandler.swift
+++ b/Sources/MockoloFramework/Operations/ImportsHandler.swift
@@ -99,10 +99,10 @@ private func renderConditionalBlock(_ block: ConditionalImportBlock, excludeImpo
     for (index, clause) in block.clauses.enumerated() {
         // Render directive line
         switch clause.type {
-        case .if:
-            result += "#if \(clause.condition ?? "")\n"
-        case .elseif:
-            result += "#elseif \(clause.condition ?? "")\n"
+        case .if(let condition):
+            result += "#if \(condition)\n"
+        case .elseif(let condition):
+            result += "#elseif \(condition)\n"
         case .else:
             result += "#else\n"
         }

--- a/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
+++ b/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
@@ -234,7 +234,7 @@ extension IfConfigDeclSyntax {
         var attrDesc: String?
         var hasInit = false
 
-        for (index, cl) in self.clauses.enumerated() {
+        for cl in self.clauses {
             guard let clauseType = ClauseType(cl) else {
                 continue
             }

--- a/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
+++ b/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
@@ -776,7 +776,7 @@ final class EntityVisitor: SyntaxVisitor {
     private func parseIfConfigDecl(_ node: IfConfigDeclSyntax) -> ConditionalImportBlock {
         var clauseList = [ConditionalImportBlock.Clause]()
 
-        for (index, cl) in node.clauses.enumerated() {
+        for cl in node.clauses {
             guard let clauseType = ClauseType(cl) else {
                 continue
             }
@@ -799,8 +799,7 @@ final class EntityVisitor: SyntaxVisitor {
 
             clauseList.append(ConditionalImportBlock.Clause(
                 type: clauseType,
-                contents: contents,
-                order: index
+                contents: contents
             ))
         }
 

--- a/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
+++ b/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
@@ -239,9 +239,9 @@ extension IfConfigDeclSyntax {
             let clauseType: ClauseType
             switch cl.poundKeyword.tokenKind {
             case .poundIf:
-                clauseType = .if
+                clauseType = .if(cl.condition?.trimmedDescription ?? "")
             case .poundElseif:
-                clauseType = .elseif(order: index)
+                clauseType = .elseif(cl.condition?.trimmedDescription ?? "")
             case .poundElse:
                 clauseType = .else
             default:
@@ -270,8 +270,8 @@ extension IfConfigDeclSyntax {
 
             clauseList.append(IfMacroModel.Clause(
                 type: clauseType,
-                condition: cl.condition?.trimmedDescription,
-                entities: uniqueSubModels
+                entities: uniqueSubModels,
+                order: index
             ))
         }
 
@@ -790,9 +790,9 @@ final class EntityVisitor: SyntaxVisitor {
             let clauseType: ClauseType
             switch cl.poundKeyword.tokenKind {
             case .poundIf:
-                clauseType = .if
+                clauseType = .if(cl.condition?.trimmedDescription ?? "")
             case .poundElseif:
-                clauseType = .elseif(order: index)
+                clauseType = .elseif(cl.condition?.trimmedDescription ?? "")
             case .poundElse:
                 clauseType = .else
             default:
@@ -817,8 +817,8 @@ final class EntityVisitor: SyntaxVisitor {
 
             clauseList.append(ConditionalImportBlock.Clause(
                 type: clauseType,
-                condition: cl.condition?.trimmedDescription,
-                contents: contents
+                contents: contents,
+                order: index
             ))
         }
 

--- a/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
+++ b/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
@@ -261,8 +261,7 @@ extension IfConfigDeclSyntax {
 
             clauseList.append(IfMacroModel.Clause(
                 type: clauseType,
-                entities: uniqueSubModels,
-                order: index
+                entities: uniqueSubModels
             ))
         }
 

--- a/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
+++ b/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
@@ -235,16 +235,7 @@ extension IfConfigDeclSyntax {
         var hasInit = false
 
         for (index, cl) in self.clauses.enumerated() {
-            // Determine clause type from the pound keyword
-            let clauseType: ClauseType
-            switch cl.poundKeyword.tokenKind {
-            case .poundIf:
-                clauseType = .if(cl.condition?.trimmedDescription ?? "")
-            case .poundElseif:
-                clauseType = .elseif(cl.condition?.trimmedDescription ?? "")
-            case .poundElse:
-                clauseType = .else
-            default:
+            guard let clauseType = ClauseType(cl) else {
                 continue
             }
 
@@ -786,16 +777,7 @@ final class EntityVisitor: SyntaxVisitor {
         var clauseList = [ConditionalImportBlock.Clause]()
 
         for (index, cl) in node.clauses.enumerated() {
-            // Determine clause type from the pound keyword
-            let clauseType: ClauseType
-            switch cl.poundKeyword.tokenKind {
-            case .poundIf:
-                clauseType = .if(cl.condition?.trimmedDescription ?? "")
-            case .poundElseif:
-                clauseType = .elseif(cl.condition?.trimmedDescription ?? "")
-            case .poundElse:
-                clauseType = .else
-            default:
+            guard let clauseType = ClauseType(cl) else {
                 continue
             }
 
@@ -976,6 +958,21 @@ extension ThrowingKind {
             } else {
                 self = .any
             }
+        }
+    }
+}
+
+extension ClauseType {
+    init?(_ syntax: IfConfigClauseSyntax) {
+        switch syntax.poundKeyword.tokenKind {
+        case .poundIf:
+            self = .if(syntax.condition?.trimmedDescription ?? "")
+        case .poundElseif:
+            self = .elseif(syntax.condition?.trimmedDescription ?? "")
+        case .poundElse:
+            self = .else
+        default:
+            return nil
         }
     }
 }

--- a/Sources/MockoloFramework/Templates/IfMacroTemplate.swift
+++ b/Sources/MockoloFramework/Templates/IfMacroTemplate.swift
@@ -26,10 +26,10 @@ extension IfMacroModel {
             // Render the directive line
             let directive: String
             switch clause.type {
-            case .if:
-                directive = "\(1.tab)#if \(clause.condition ?? "")"
-            case .elseif:
-                directive = "\(1.tab)#elseif \(clause.condition ?? "")"
+            case .if(let condition):
+                directive = "\(1.tab)#if \(condition)"
+            case .elseif(let condition):
+                directive = "\(1.tab)#elseif \(condition)"
             case .else:
                 directive = "\(1.tab)#else"
             }

--- a/Tests/TestMacros/FixtureMacro.swift
+++ b/Tests/TestMacros/FixtureMacro.swift
@@ -540,7 +540,7 @@ let nestedMacroMock = """
 #if canImport(NewFramework)
 import Z
 #if canImport(NewFramework2)
-import W
+@testable import W
 #if canImport(NewFramework3)
 import Z
 #endif

--- a/Tests/TestMacros/MacroTests.swift
+++ b/Tests/TestMacros/MacroTests.swift
@@ -67,7 +67,8 @@ final class MacroTests: MockoloTestCase {
     func testNestedMacro() {
         verify(
             srcContent: nestedMacro,
-            dstContent: nestedMacroMock
+            dstContent: nestedMacroMock,
+            testableImports: ["W"]
         )
     }
 }


### PR DESCRIPTION
いくつか気になったポイントがあり、指摘を的確に伝えることが難しい面があったためこちらで修正しました。

- `Import.swift`への変更は不要であるため戻しておきます。
    - https://github.com/uber/mockolo/pull/328#discussion_r2587106797 のコメントは元々このファイルへの差分が気になっていたからでした。
- `ClauseType`について、構造に気になった点があり少し整理しています。
    - `condition`プロパティが外側に置かれていて「elseの時はnil」という運用でしたが、気をつけて読む負担が大きく感じたためSwift文法上の構造の形を優先しました。
    - `elseif`のorderについて、条件文のモデルに節の順序が混じっていることは不適切と感じました。節の順序の関心は節の中身までを含めた、より広いモデル側が扱うべきと思いました。そしてこのorderは一切使用されていなかったため、そのまま削除されました。
- `ImportContent`の`isConditional`について、これを利用している側のロジックが明らかに冗長だったため、取り除いて素直な記述に変更しました。のちに使わなくなったので削除されました。
- 今回の変更で`Import`が持つ`prefix` `suffix`プロパティの出番がなくなっているはずで、削除が必要でした。
- `renderConditionalBlock`で`testableImports`についての取り扱いがなく、元の挙動が壊れていたのではないかと思います。
- トップレベルとブロック内とでロジックが大きく分かれている点が気になりました。同じロジックが正しく実装されているか確認する必要が出てきています。トップレベルとブロック内を区別しないよう`[ImportContent]`の単位で再帰を行うよう変更しています。その結果、全体のロジックの行数もかなり小さくなりました。
    
